### PR TITLE
chore: Filter entries to sentry

### DIFF
--- a/bibxml/settings.py
+++ b/bibxml/settings.py
@@ -100,8 +100,8 @@ if environ.get("SENTRY_DSN", None):
         integrations=[
             DjangoIntegration(),
             LoggingIntegration(
-                level=logging.INFO,
-                event_level=logging.WARNING,
+                level=logging.ERROR,
+                event_level=logging.ERROR,
             ),
         ],
         server_name=HOSTNAME,


### PR DESCRIPTION
Send only ERRORs as events and log only log messages above WARNING level.