### PR TITLE
ci: Restrict mypy to < 1.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: "3.10"
       - uses: actions/checkout@v3
       - name: Install mypy
-        run: pip install mypy && pip install -r requirements.txt
+        run: pip install "mypy<1.0.0" && pip install -r requirements.txt
       - name: Run mypy
         run: mypy --ignore-missing-imports --install-types --non-interactive .
       - name: Build the Docker image


### PR DESCRIPTION
Test GHA is failing with `mypy==1.0.0`.