### PR TITLE
fix: IDs XML target URL

### DIFF
--- a/datatracker/internet_drafts.py
+++ b/datatracker/internet_drafts.py
@@ -80,6 +80,7 @@ def get_internet_draft(
         raise RefNotFoundError()
 
     data = resp.json()
+    data['resource_uri'] = data.get('resource_uri').replace('api/v1/doc/document/', 'doc/html/')
 
     bibitem_data: Dict[str, Any] = dict(
         type='draft',

--- a/main/query.py
+++ b/main/query.py
@@ -459,7 +459,7 @@ def build_citation_for_docid(
     ])
     if primary_docid:
         refs = query_suppressing_user_input_error(
-            lambda: search_refs_docids(typeCast(DocID, primary_docid))
+            lambda: search_refs_docids(primary_docid)
         ) or []
 
     composite_item, valid = compose_bibitem(


### PR DESCRIPTION
This is an hotfix for #378 , as I understood this issue is [blocking from releasing a new draft](https://github.com/ietf-tools/bibxml-service/issues/378#issuecomment-1791161814)

The issue behind having the malformed URL for some IDs is still under investigation.