### PR TITLE
fix: adds datasets volume to helm chart for k8s deployment

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -89,17 +89,15 @@ autoscaling:
   # targetMemoryUtilizationPercentage: 80
 
 # Additional volumes on the output Deployment definition.
-volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
+volumes:
+  - name: datasets
+    emptyDir:
+      sizeLimit: 5Gi
 
 # Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
-#   readOnly: true
+volumeMounts:
+  - name: datasets
+    mountPath: /data/datasets
 
 nodeSelector: {}
 


### PR DESCRIPTION
Creates a 5Gi volume for indexing of pulled datasets.  The size may need to be adjusted, but this adds a volume which previously didn't exist but is needed.
