### PR TITLE
fix: Use correct environment variable for release version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
           file: Dockerfile
           push: true
           build-args: |
-            VERSION=${{ steps.semver.outputs.nextStrict }}
+            SNAPSHOT=${{ steps.semver.outputs.nextStrict }}
           platforms: linux/amd64,linux/arm64
           tags: ghcr.io/${{ github.repository }}:${{ steps.semver.outputs.nextStrict }}, ghcr.io/${{ github.repository }}:latest
 


### PR DESCRIPTION
Fixes #429 

---

The environment variable being used in https://github.com/ietf-tools/bibxml-service/blob/main/docs/conf.py is `SNAPSHOT`, not `VERSION`.

```python
release = f"v{os.environ.get('SNAPSHOT', 'N/A') or 'N/A'}"
```

Please double check if `VERSION` is currently being used elsewhere.