### PR TITLE
chore: Handle missing environment variables for local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       PRIMARY_HOSTNAME: ${HOST_NAME?missing main hostname (e.g., localhost for development)}
       INTERNAL_HOSTNAMES: "web"
       DEBUG: ${DEBUG:-0}
-      SOURCE_REPO_URL: ${SOURCE_REPO_URL:?missing source repository URL}
+      SOURCE_REPO_URL: ${SOURCE_REPO_URL}
       DJANGO_SECRET: "${DJANGO_SECRET:?missing Django secret (long random string)}"
       API_SECRET: "${API_SECRET:?missing API secret}"
       EXTRA_API_SECRETS: "${EXTRA_API_SECRETS}"

--- a/docs/howto/develop-locally.rst
+++ b/docs/howto/develop-locally.rst
@@ -58,7 +58,7 @@ Building base image
       DB_NAME=bibxml
       DB_SECRET=qwert
       DJANGO_SECRET=FDJDSLJFHUDHJCTKLLLCMNII(****#TEFF
-      HOST=localhost
+      HOST_NAME=localhost
       API_SECRET=test
       SERVICE_NAME=IETF BibXML service
       CONTACT_EMAIL=<ops contact email>


### PR DESCRIPTION
Fixes #432

I could've added `SOURCE_REPO_URL` to `.env` in the documentation instead of changing `docker-compose.yml`, but decided to treat it like `MATOMO_URL`, `MATOMO_SITE_ID`, etc. at the end. Let me know.