### PR TITLE
chore: Mark /code as safe directory in Git settings

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,6 +13,7 @@ services:
       - /bin/sh
       - -c
       - |
+        git config --global --add safe.directory /code &&
         export SNAPSHOT=$$(git describe --abbrev=0) &&
         npm install &&
         ./wait-for-migrations.sh &&

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,7 @@ services:
       - /bin/sh
       - -c
       - |
+        git config --global --add safe.directory /code &&
         export SNAPSHOT=$$(git describe --abbrev=0) &&
         ./wait-for-migrations.sh &&
         celery -A sources.celery:app worker -B -l info -c 1


### PR DESCRIPTION
Fixes #434 

Running `git config --global --add safe.directory /code` prior to calling `git describe --abbrev=0` seems to fix the issue. See the last comment, https://github.com/ietf-tools/bibxml-service/issues/434#issuecomment-2213044940, for more info.