### PR TITLE
refactor: Optimise landing page performance

### DIFF
--- a/main/query.py
+++ b/main/query.py
@@ -8,7 +8,6 @@ from typing import Dict, List, Union, Tuple, Any
 
 from django.contrib.postgres.search import SearchQuery
 from django.contrib.postgres.search import SearchHeadline
-from django.db import connection
 from django.db.models.functions import Cast
 from django.db.models import TextField
 from django.db.models.query import QuerySet, Q
@@ -763,18 +762,3 @@ def get_indexed_ref_by_query(
         raise RefNotFoundError(
             "Multiple references match query in given dataset",
             repr(Q))
-
-
-def estimate_count(table_name: str) -> int:
-    """Returns the estimated number of rows in a given table.
-
-    :param str table_name: table name
-    :rtype: int
-    """
-    with connection.cursor() as cursor:
-        cursor.execute(
-            "SELECT reltuples FROM pg_class WHERE relname = %s",
-            [table_name],
-        )
-        row = cursor.fetchone()
-        return int(row[0])

--- a/main/query.py
+++ b/main/query.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Union, Tuple, Any
 
 from django.contrib.postgres.search import SearchQuery
 from django.contrib.postgres.search import SearchHeadline
+from django.db import connection
 from django.db.models.functions import Cast
 from django.db.models import TextField
 from django.db.models.query import QuerySet, Q
@@ -762,3 +763,18 @@ def get_indexed_ref_by_query(
         raise RefNotFoundError(
             "Multiple references match query in given dataset",
             repr(Q))
+
+
+def estimate_count(table_name: str) -> int:
+    """Returns the estimated number of rows in a given table.
+
+    :param str table_name: table name
+    :rtype: int
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT reltuples FROM pg_class WHERE relname = %s",
+            [table_name],
+        )
+        row = cursor.fetchone()
+        return int(row[0])

--- a/main/templates/browse/home.html
+++ b/main/templates/browse/home.html
@@ -40,8 +40,8 @@
   <div class="{% include "_side_block_classes.html" %} md:row-span-3">
     <p class="text-xs m-4">
       {% if browsable_datasets %}
-        {{ total_indexed_human }} bibliographic&nbsp;items
-        now indexed among&nbsp;sources:
+        Bibliographic&nbsp;items
+        are indexed among&nbsp;sources:
         {% for ds_id in browsable_datasets %}
           <a class="{% if dataset_id == ds_id %}font-bold{% endif %}" href="{% url "browse_dataset" ds_id %}"
             >{{ ds_id }}</a>{% if not forloop.last %}, {% endif %}

--- a/main/views.py
+++ b/main/views.py
@@ -56,18 +56,8 @@ def home(request):
 
     metrics.gui_home_page_hits.inc()
 
-    total_indexed_citations = RefData.objects.count()
-    units = ('', 'k', 'M', 'G', 'T', 'P')
-    factor = 1000.0
-    magnitude = int(floor(log_(max(abs(total_indexed_citations), 1), factor)))
-    total_indexed_human = '%.2f%s' % (
-        total_indexed_citations / factor**magnitude,
-        units[magnitude],
-    )
-
     return render(request, 'browse/home.html', dict(
         **shared_context,
-        total_indexed_human=total_indexed_human,
         browsable_datasets=settings.RELATON_DATASETS,
     ))
 

--- a/main/views.py
+++ b/main/views.py
@@ -56,10 +56,6 @@ def home(request):
 
     metrics.gui_home_page_hits.inc()
 
-    non_empty_datasets = (
-        RefData.objects.values_list('dataset', flat=True).
-        distinct())
-
     total_indexed_citations = RefData.objects.count()
     units = ('', 'k', 'M', 'G', 'T', 'P')
     factor = 1000.0
@@ -69,15 +65,10 @@ def home(request):
         units[magnitude],
     )
 
-    browsable_datasets = [
-        ds_id
-        for ds_id in settings.RELATON_DATASETS
-        if ds_id in non_empty_datasets]
-
     return render(request, 'browse/home.html', dict(
         **shared_context,
         total_indexed_human=total_indexed_human,
-        browsable_datasets=browsable_datasets,
+        browsable_datasets=settings.RELATON_DATASETS,
     ))
 
 

--- a/main/views.py
+++ b/main/views.py
@@ -5,6 +5,7 @@ from math import log as log_, floor
 from urllib.parse import unquote_plus
 import json
 
+from django.db import connection
 from django.db.models.query import QuerySet
 from django.urls import reverse
 from django.http import QueryDict
@@ -24,7 +25,7 @@ from bib_models import serializers, BibliographicItem
 from xml2rfc_compat import adapters as xml2rfc_adapters
 
 from .models import RefData
-from .query import get_indexed_item, list_refs, estimate_count
+from .query import get_indexed_item, list_refs
 from .query import build_citation_for_docid
 from .search import BaseCitationSearchView
 from .search import QUERY_FORMAT_LABELS
@@ -51,12 +52,22 @@ shared_context = dict(
 """Shared context passed to GUI templates."""
 
 
+def _count_estimate(table_name: str) -> int:
+    with connection.cursor() as cursor:
+        cursor.execute(
+            'SELECT reltuples FROM pg_class WHERE relname = %s',
+            [table_name],
+        )
+        row = cursor.fetchone()
+        return int(row[0])
+
+
 def home(request):
     """Serves main landing page."""
 
     metrics.gui_home_page_hits.inc()
 
-    total_indexed_citations = estimate_count('api_ref_data')  # Use estimate
+    total_indexed_citations = _count_estimate('api_ref_data')  # Use estimate
     units = ('', 'k', 'M', 'G', 'T', 'P')
     factor = 1000.0
     magnitude = int(floor(log_(max(abs(total_indexed_citations), 1), factor)))

--- a/main/views.py
+++ b/main/views.py
@@ -5,7 +5,6 @@ from math import log as log_, floor
 from urllib.parse import unquote_plus
 import json
 
-from django.db import connection
 from django.db.models.query import QuerySet
 from django.urls import reverse
 from django.http import QueryDict
@@ -52,22 +51,12 @@ shared_context = dict(
 """Shared context passed to GUI templates."""
 
 
-def _count_estimate(table_name: str) -> int:
-    with connection.cursor() as cursor:
-        cursor.execute(
-            'SELECT reltuples FROM pg_class WHERE relname = %s',
-            [table_name],
-        )
-        row = cursor.fetchone()
-        return int(row[0])
-
-
 def home(request):
     """Serves main landing page."""
 
     metrics.gui_home_page_hits.inc()
 
-    total_indexed_citations = _count_estimate('api_ref_data')  # Use estimate
+    total_indexed_citations = RefData.objects.count()
     units = ('', 'k', 'M', 'G', 'T', 'P')
     factor = 1000.0
     magnitude = int(floor(log_(max(abs(total_indexed_citations), 1), factor)))

--- a/main/views.py
+++ b/main/views.py
@@ -5,6 +5,7 @@ from math import log as log_, floor
 from urllib.parse import unquote_plus
 import json
 
+from django.db import connection
 from django.db.models.query import QuerySet
 from django.urls import reverse
 from django.http import QueryDict
@@ -51,12 +52,22 @@ shared_context = dict(
 """Shared context passed to GUI templates."""
 
 
+def _count_estimate(table_name: str) -> int:
+    with connection.cursor() as cursor:
+        cursor.execute(
+            'SELECT reltuples FROM pg_class WHERE relname = %s',
+            [table_name],
+        )
+        row = cursor.fetchone()
+        return int(row[0])
+
+
 def home(request):
     """Serves main landing page."""
 
     metrics.gui_home_page_hits.inc()
 
-    total_indexed_citations = RefData.objects.count()
+    total_indexed_citations = _count_estimate('api_ref_data')  # Use estimate
     units = ('', 'k', 'M', 'G', 'T', 'P')
     factor = 1000.0
     magnitude = int(floor(log_(max(abs(total_indexed_citations), 1), factor)))

--- a/main/views.py
+++ b/main/views.py
@@ -5,7 +5,6 @@ from math import log as log_, floor
 from urllib.parse import unquote_plus
 import json
 
-from django.db import connection
 from django.db.models.query import QuerySet
 from django.urls import reverse
 from django.http import QueryDict
@@ -25,7 +24,7 @@ from bib_models import serializers, BibliographicItem
 from xml2rfc_compat import adapters as xml2rfc_adapters
 
 from .models import RefData
-from .query import get_indexed_item, list_refs
+from .query import get_indexed_item, list_refs, estimate_count
 from .query import build_citation_for_docid
 from .search import BaseCitationSearchView
 from .search import QUERY_FORMAT_LABELS
@@ -52,22 +51,12 @@ shared_context = dict(
 """Shared context passed to GUI templates."""
 
 
-def _count_estimate(table_name: str) -> int:
-    with connection.cursor() as cursor:
-        cursor.execute(
-            'SELECT reltuples FROM pg_class WHERE relname = %s',
-            [table_name],
-        )
-        row = cursor.fetchone()
-        return int(row[0])
-
-
 def home(request):
     """Serves main landing page."""
 
     metrics.gui_home_page_hits.inc()
 
-    total_indexed_citations = _count_estimate('api_ref_data')  # Use estimate
+    total_indexed_citations = estimate_count('api_ref_data')  # Use estimate
     units = ('', 'k', 'M', 'G', 'T', 'P')
     factor = 1000.0
     magnitude = int(floor(log_(max(abs(total_indexed_citations), 1), factor)))


### PR DESCRIPTION
This PR is to optimise the performance of the landing page.

Currently, it makes two separate database calls every time `/` is hit.

1.  ``` sql
    SELECT DISTINCT "api_ref_data"."dataset" FROM "api_ref_data"; -- SQL
    ```

    ``` python
    RefData.objects.values_list('dataset', flat=True).distinct()  # Django ORM
    ```

2.  ``` sql
    SELECT COUNT(*) AS "__count" FROM "api_ref_data"; -- SQL
    ```

    ``` python
    RefData.objects.count()  # Django ORM
    ```

(Note: Even with indexes in the database, the landing page has failed to load in non-prod environments where resources are more scarce.)

The query results are then used to display a message like

> 268.58k bibliographic items now indexed among sources: rfcs, ids, rfcsubseries, misc, w3c, 3gpp, ieee, iana, nist

The first query determines whether each of the datasets is browsable or not. If browsable, it will embed a clickable link in the message (e.g. `/indexed-sources/relaton-data-rfcs/`), otherwise it will be omitted. IMO, the query is not necessary - we can simply mark all datasets as browsable.

Re: the second query, we can use an estimated count rather than an exact count. We have to use a raw query for that since it's specific to Postgres.
