### PR TITLE
build: Expose access logs

### DIFF
--- a/k8s/bib.yaml
+++ b/k8s/bib.yaml
@@ -51,7 +51,7 @@ spec:
               python manage.py migrate &&
               python manage.py check --deploy &&
               python manage.py clear_cache &&
-              hypercorn -b '0.0.0.0:8000' -w 1 bibxml.asgi:application
+              hypercorn -b '0.0.0.0:8000' -w 1 --access-logfile - bibxml.asgi:application
         - name: celery
           image: "ghcr.io/ietf-tools/bibxml-service:$APP_IMAGE_TAG"
           imagePullPolicy: Always

--- a/k8s/bib.yaml
+++ b/k8s/bib.yaml
@@ -51,7 +51,7 @@ spec:
               python manage.py migrate &&
               python manage.py check --deploy &&
               python manage.py clear_cache &&
-              hypercorn -b '0.0.0.0:8000' -w 1 --access-logfile - bibxml.asgi:application
+              hypercorn -b '0.0.0.0:8000' -w 9 --access-logfile - bibxml.asgi:application
         - name: celery
           image: "ghcr.io/ietf-tools/bibxml-service:$APP_IMAGE_TAG"
           imagePullPolicy: Always


### PR DESCRIPTION
* Access logs are written into `stdout` with this change[^1].
* The number of workers is set to `2*(#cpus)+1`.

[^1]: https://hypercorn.readthedocs.io/en/stable/how_to_guides/configuring.html#configuration-options