### PR TITLE
build: upgrade Docker images to Python 3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.10-slim@sha256:502f6626d909ab4ce182d85fcaeb5f73cf93fcb4e4a5456e83380f7b146b12d3
-# FROM python:3.11-rc-slim -- no lxml wheel yet
+FROM python:3.14-slim
 
 ENV PYTHONUNBUFFERED=1
 

--- a/pyright.lsp.Dockerfile
+++ b/pyright.lsp.Dockerfile
@@ -1,7 +1,6 @@
 # syntax=docker/dockerfile:1
-FROM python:3.10-slim@sha256:502f6626d909ab4ce182d85fcaeb5f73cf93fcb4e4a5456e83380f7b146b12d3
+FROM python:3.14-slim
 
-# FROM python:3.11-rc-slim -- no lxml wheel yet
 # FROM lspcontainers/pyright-langserver
 
 ENV PYTHONUNBUFFERED=1

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,6 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.10-slim@sha256:502f6626d909ab4ce182d85fcaeb5f73cf93fcb4e4a5456e83380f7b146b12d3
-# FROM python:3.11-rc-slim -- no lxml wheel yet
+FROM python:3.14-slim
 
 RUN ["python", "-m", "pip", "install", "--upgrade", "pip"]
 


### PR DESCRIPTION
Bump the base image in Dockerfile, test.Dockerfile, and pyright.lsp.Dockerfile from python:3.10-slim to python:3.14-slim. Drop the pinned 3.10 digest and remove the obsolete python:3.11-rc-slim comment now that lxml ships cp314 wheels.

Fixes #516 


Model: claude-opus-4-8 (thinking: medium)